### PR TITLE
Update README.md, fixed broken link after latest release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ACME Issuer with [cert-manager](https://cert-manager.io/docs/).
 ```bash
 helm install stackit-cert-manager-webhook \
   --namespace cert-manager \
-  https://github.com/stackitcloud/stackit-cert-manager-webhook/releases/download/v0.1.2/stackit-cert-manager-webhook-v0.1.2.tgz
+  https://github.com/stackitcloud/stackit-cert-manager-webhook/releases/download/v0.1.2/stackit-cert-manager-webhook-0.1.2.tgz
 ```
 
 ## Usage


### PR DESCRIPTION
Hi,

seems like after the latest release the naming of the release got changed. The link from the step-by-step guide is not working because of that. This PR fixes the small change so that people can again blindly follow the instructions ;-)