### PR TITLE
feat: Publish helm index to gh-pages branch

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -1,0 +1,41 @@
+name: publish_helm_chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/publish-chart.yaml"
+      - "deploy/**"
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+        with:
+          charts_dir: deploy
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR creates a Helm repository using GH as registry. Using https://github.com/helm/chart-releaser-action , any new version of the chart will generate a GH Release and include the link within the index.yaml file of gh-page branch (the branch needs to be created manually before). 
This enables using helm to discover the charts and also enables including OCI support easily if it's something desired (e.g: https://github.com/argoproj/argo-helm/pull/2209).

This PR requires another manual action that it's enabling GH Pages from `gh-pages` branch, publishing the root path


Fixes https://github.com/stackitcloud/stackit-cert-manager-webhook/issues/40