### PR TITLE
chore: Bump helm chart to trigger the helm repository generation correctly

### DIFF
--- a/deploy/stackit/Chart.yaml
+++ b/deploy/stackit/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: stackit-cert-manager-webhook
-version: 0.2.0
+version: 0.2.1


### PR DESCRIPTION
To trigger a new release with the correct values, this PR just bump the helm chart

Related #40 