### PR TITLE
fix: Use the full value on certificates to avoid out-of-sync status

### DIFF
--- a/deploy/stackit/templates/pki.yaml
+++ b/deploy/stackit/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "stackit-cert-manager-webhook.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "stackit-cert-manager-webhook.selfSignedIssuer" . }}
   commonName: "ca.stackit-cert-manager-webhook.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "stackit-cert-manager-webhook.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "stackit-cert-manager-webhook.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
As cert-manager default values include minutes and seconds, they are added as default. This is not a problem itself, but with gitops tools like ArgoCD, this difference is found as mismatch, triggering the resync to fix it (although it won't be fixed ever)
![image](https://github.com/user-attachments/assets/d8ed68ec-d864-4558-9b05-7f76db6689a7)

This PR adds the minutes and seconds using default value

This can be solved also excluding the field from ArgoCD, but solving it on the chart side is better as it solves the issue for everybody
