### PR TITLE
feat(helm): add extraenvs to helm values

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -8,6 +8,7 @@ scopes:
   - cli
   - ci
   - deps
+  - helm
 
 types:
   - feat

--- a/deploy/stackit/templates/deployment.yaml
+++ b/deploy/stackit/templates/deployment.yaml
@@ -36,6 +36,12 @@ spec:
             - name: STACKIT_SERVICE_ACCOUNT_KEY_PATH
               value: "{{ .Values.stackitSaAuthentication.mountPath}}/{{ .Values.stackitSaAuthentication.fileName}}"
             {{- end }}
+            {{- if .Values.extraEnv }}
+            {{- range .Values.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: https
               containerPort: 8443

--- a/deploy/stackit/values.yaml
+++ b/deploy/stackit/values.yaml
@@ -94,3 +94,12 @@ additionalVolumeMounts: []
 #   - name: extra-config
 #     mountPath: /etc/extra-config
 #     readOnly: true
+
+# -- Placeholder for additional env-variables. Apply via "--set"-command  or 
+# -- delete the next line and add your variables as in the commented example below.
+extraEnv: []
+# extraEnv:
+#   - name: HTTP_PROXY
+#     value: "127.0.0.1"
+#   - name: ANOTHER_VAR
+#     value: "some-value"


### PR DESCRIPTION
Manual testing of the deployment, both with and without additional environment variables, was successful.