### PR TITLE
fix: update chart-testing setup to use direct command execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,11 +54,11 @@ jobs:
       - name: Runs all tests
         run: make test
 
-      - name: Run chart-testing (lint)
+      - name: Set up chart-testing
         uses: helm/chart-testing-action@main
-        with:
-          command: lint
-          config: .github/ct.yaml
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config .github/ct.yaml
 
       - name: Runs helm docs
         run: make helm-docs


### PR DESCRIPTION
This pull request updates the way chart-testing is set up and executed in the GitHub Actions workflow. The main improvement is separating the setup of the chart-testing action from the actual linting command, making the workflow steps clearer and more modular.

**Workflow improvements:**

* Split the chart-testing step into two: one step to set up the `helm/chart-testing-action`, and a separate step to run the `ct lint` command directly with the specified config file.