### PR TITLE
feat: Support service account annotations for WIF

### DIFF
--- a/deploy/stackit/templates/rbac.yaml
+++ b/deploy/stackit/templates/rbac.yaml
@@ -12,6 +12,10 @@ metadata:
     chart: {{ include "stackit-cert-manager-webhook.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations}}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 ---
 # Grant the webhook permission to read the ConfigMap containing the Kubernetes
 # apiserver's requestheader-ca-certificate.

--- a/deploy/stackit/values.yaml
+++ b/deploy/stackit/values.yaml
@@ -19,6 +19,11 @@ certManager:
   # -- service account name for the cert-manager.
   serviceAccountName: cert-manager
 
+# -- Service Account 
+serviceAccount:
+  # -- service account annotations.
+  annotations: {}
+ 
 # -- Image information for the webhook.
 image:
   # -- repository of the image.


### PR DESCRIPTION
To support WIF, we need to add annotations to the service account in order to inject the needed stuff using https://github.com/stackitcloud/stackit-pod-identity-webhook/blob/main/README.md